### PR TITLE
Drop Projection Matrix Config; Make explicit.

### DIFF
--- a/test/categories/MatrixOps.h
+++ b/test/categories/MatrixOps.h
@@ -249,7 +249,7 @@ TEST(InvMatrix, InvGeneral)
 TEST(InvMatrix, Mat4Inverses)
 {
     {
-        HMM_Mat4 Matrix = HMM_Orthographic_RH(-160+100, 160+100, -90+200, 90+200, 10, 10000);
+        HMM_Mat4 Matrix = HMM_Orthographic_N0_RH(-160+100, 160+100, -90+200, 90+200, 10, 10000);
         HMM_Mat4 Expect = HMM_M4D(1.0f);
         HMM_Mat4 Inverse = HMM_InvOrthographic(Matrix);
         HMM_Mat4 Result = HMM_MulM4(Matrix, Inverse);
@@ -272,10 +272,10 @@ TEST(InvMatrix, Mat4Inverses)
         EXPECT_FLOAT_EQ(Result.Elements[3][0], Expect.Elements[3][0]);
         EXPECT_FLOAT_EQ(Result.Elements[3][1], Expect.Elements[3][1]);
         EXPECT_FLOAT_EQ(Result.Elements[3][2], Expect.Elements[3][2]);
-        EXPECT_FLOAT_EQ(Result.Elements[3][3], Expect.Elements[3][3]);        
+        EXPECT_FLOAT_EQ(Result.Elements[3][3], Expect.Elements[3][3]);
     }
     {
-        HMM_Mat4 Matrix = HMM_Perspective_RH(HMM_AngleDeg(120), 16.0/9.0, 10, 10000);
+        HMM_Mat4 Matrix = HMM_Perspective_N0_RH(HMM_AngleDeg(120), 16.0/9.0, 10, 10000);
         HMM_Mat4 Expect = HMM_M4D(1.0f);
         HMM_Mat4 Inverse = HMM_InvPerspective(Matrix);
         HMM_Mat4 Result = HMM_MulM4(Matrix, Inverse);

--- a/test/categories/Projection.h
+++ b/test/categories/Projection.h
@@ -3,47 +3,66 @@
 TEST(Projection, Orthographic)
 {
     {
-        HMM_Mat4 projection = HMM_Orthographic_RH(-10.0f, 10.0f, -5.0f, 5.0f, 0.0f, -10.0f);
-
-        HMM_Vec3 original = HMM_V3(5.0f, 5.0f, -5.0f);
-        HMM_Vec4 projected = HMM_MulM4V4(projection, HMM_V4V(original, 1));
+        HMM_Mat4 projection = HMM_Orthographic_N0_RH(-10.0f, 10.0f, -5.0f, 5.0f, 1.0f, 10.0f);
+        HMM_Vec4 original = HMM_V4(5.0f, 5.0f, -1.0f, 1.0);
+        HMM_Vec4 projected = HMM_MulM4V4(projection, original);
 
         EXPECT_FLOAT_EQ(projected.X, 0.5f);
         EXPECT_FLOAT_EQ(projected.Y, 1.0f);
-        EXPECT_FLOAT_EQ(projected.Z, -2.0f);
+        EXPECT_FLOAT_EQ(projected.Z, -1.0f);
         EXPECT_FLOAT_EQ(projected.W, 1.0f);
+
+        /* Z0 */
+        projection = HMM_Orthographic_Z0_RH(-10.0f, 10.0f, -5.0f, 5.0f, 1.0f, -10.0f);
+        projected = HMM_MulM4V4(projection, original);
+        EXPECT_FLOAT_EQ(projected.Z, 0.0f);
     }
     {
-        HMM_Mat4 projection = HMM_Orthographic_LH(-10.0f, 10.0f, -5.0f, 5.0f, 0.0f, 10.0f);
-
-        HMM_Vec3 original = HMM_V3(5.0f, 5.0f, -5.0f);
-        HMM_Vec4 projected = HMM_MulM4V4(projection, HMM_V4V(original, 1));
-
+        HMM_Mat4 projection = HMM_Orthographic_N0_LH(-10.0f, 10.0f, -5.0f, 5.0f, 1.0f, -10.0f);
+        HMM_Vec4 original = HMM_V4(5.0f, 5.0f, 1.0f, 1.0);
+        HMM_Vec4 projected = HMM_MulM4V4(projection, original);
+        
         EXPECT_FLOAT_EQ(projected.X, 0.5f);
         EXPECT_FLOAT_EQ(projected.Y, 1.0f);
-        EXPECT_FLOAT_EQ(projected.Z, -2.0f);
+        EXPECT_FLOAT_EQ(projected.Z, -1.0f);
         EXPECT_FLOAT_EQ(projected.W, 1.0f);
+
+        /* Z0 */
+        projection = HMM_Orthographic_Z0_LH(-10.0f, 10.0f, -5.0f, 5.0f, 1.0f, -10.0f);
+        projected = HMM_MulM4V4(projection, original);
+        EXPECT_FLOAT_EQ(projected.Z, 0.0f);
     }
 }
 
 TEST(Projection, Perspective)
 {
     {
-        HMM_Mat4 projection = HMM_Perspective_RH(HMM_AngleDeg(90.0f), 2.0f, 5.0f, 15.0f);
-        HMM_Vec3 original = HMM_V3(5.0f, 5.0f, -15.0f);
-        HMM_Vec4 projected = HMM_MulM4V4(projection, HMM_V4V(original, 1));
+        HMM_Mat4 projection = HMM_Perspective_N0_RH(HMM_AngleDeg(90.0f), 2.0f, 1.0f, 15.0f);
+        HMM_Vec4 original = HMM_V4(5.0f, 5.0f, -1.0f, 1.0f);
+        HMM_Vec4 projected = HMM_MulM4V4(projection, original);
         EXPECT_FLOAT_EQ(projected.X, 2.5f);
         EXPECT_FLOAT_EQ(projected.Y, 5.0f);
-        EXPECT_FLOAT_EQ(projected.Z, 15.0f);
-        EXPECT_FLOAT_EQ(projected.W, 15.0f);
+        EXPECT_FLOAT_EQ(projected.Z, -1.0f);
+        EXPECT_FLOAT_EQ(projected.W, 1.0f);
+
+        /* Z0 */
+        projection = HMM_Perspective_Z0_RH(HMM_AngleDeg(90.0f), 2.0f, 1.0f, 15.0f);
+        projected = HMM_MulM4V4(projection, original);
+        EXPECT_FLOAT_EQ(projected.Z, 0.0f);
     }
+    
     {
-        HMM_Mat4 projection = HMM_Perspective_LH(HMM_AngleDeg(90.0f), 2.0f, 5.0f, 15.0f);
-        HMM_Vec3 original = HMM_V3(5.0f, 5.0f, -15.0f);
-        HMM_Vec4 projected = HMM_MulM4V4(projection, HMM_V4V(original, 1));
+        HMM_Mat4 projection = HMM_Perspective_N0_LH(HMM_AngleDeg(90.0f), 2.0f, 1.0f, 15.0f);
+        HMM_Vec4 original = HMM_V4(5.0f, 5.0f, 1.0f, 1.0f);
+        HMM_Vec4 projected = HMM_MulM4V4(projection, original);
         EXPECT_FLOAT_EQ(projected.X, 2.5f);
         EXPECT_FLOAT_EQ(projected.Y, 5.0f);
-        EXPECT_FLOAT_EQ(projected.Z, 15.0f);
-        EXPECT_FLOAT_EQ(projected.W, -15.0f);
+        EXPECT_FLOAT_EQ(projected.Z, -1.0f);
+        EXPECT_FLOAT_EQ(projected.W, 1.0f);
+        
+        /* Z0 */
+        projection = HMM_Perspective_Z0_LH(HMM_AngleDeg(90.0f), 2.0f, 1.0f, 15.0f);
+        projected = HMM_MulM4V4(projection, original);
+        EXPECT_FLOAT_EQ(projected.Z, 0.0f);
     }
 }

--- a/update/update_hmm.c
+++ b/update/update_hmm.c
@@ -482,8 +482,15 @@ Str8List update_file_content(Arena* arena, str8 file_content) {
                         
                         chr8 check = file_content.str[i+1];
                         if (check == '(') {
-                            printf("\t[%u]: Find: %.*s, Appending: _RH for old default handedness.\n", Line, str8_PRINTF_ARGS(Find[t]));
                             Str8List_add(arena, &out, str8_first(file_content, i + 1));
+
+                            if (t == HAND_PERSPECTIVE || t == HAND_ORTHO) {
+                                printf("\t[%u]: Appending _N0 for old default NDC.\n", Line, str8_PRINTF_ARGS(Find[t]));
+                                Str8List_add(arena, &out, str8_lit("_N0"));
+                            }
+
+                            printf("\t[%u]: Find: %.*s, Appending: _RH for old default handedness.\n", Line, str8_PRINTF_ARGS(Find[t]));
+                            
                             Str8List_add(arena, &out, str8_lit("_RH("));
                             file_content = str8_skip(file_content, i+2);
                             i = -1;


### PR DESCRIPTION
Change projection matrix functions to be explicit about NDC: N0 means NDC Z is in [-1, 1], whereas Z0 means NDC Z is in [0, 1]. The configuration macro HANDMADE_MATH_USE_NDC_Z01 has been removed.

See conversation here: https://discord.com/channels/239737791225790464/239737791225790464/1067617107694600262