### PR TITLE
Provide const versions of operator[]

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -244,10 +244,8 @@ typedef union HMM_Vec2
     float Elements[2];
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
-    {
-        return Elements[Index];
-    }
+    inline float &operator[](int Index) { return Elements[Index]; }
+    inline const float& operator[](int Index) const { return Elements[Index]; }
 #endif
 } HMM_Vec2;
 
@@ -295,10 +293,8 @@ typedef union HMM_Vec3
     float Elements[3];
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
-    {
-        return Elements[Index];
-    }
+    inline float &operator[](int Index) { return Elements[Index]; }
+    inline const float &operator[](int Index) const { return Elements[Index]; }
 #endif
 } HMM_Vec3;
 
@@ -359,10 +355,8 @@ typedef union HMM_Vec4
 #endif
 
 #ifdef __cplusplus
-    inline float &operator[](int Index)
-    {
-        return Elements[Index];
-    }
+    inline float &operator[](int Index) { return Elements[Index]; }
+    inline const float &operator[](int Index) const { return Elements[Index]; }
 #endif
 } HMM_Vec4;
 
@@ -372,10 +366,8 @@ typedef union HMM_Mat2
     HMM_Vec2 Columns[2];
 
 #ifdef __cplusplus
-    inline HMM_Vec2 &operator[](int Index)
-    {
-        return Columns[Index];
-    }
+    inline HMM_Vec2 &operator[](int Index) { return Columns[Index]; }
+    inline const HMM_Vec2 &operator[](int Index) const { return Columns[Index]; }
 #endif
 } HMM_Mat2;
     
@@ -385,10 +377,8 @@ typedef union HMM_Mat3
     HMM_Vec3 Columns[3];
 
 #ifdef __cplusplus
-    inline HMM_Vec3 &operator[](int Index)
-    {
-        return Columns[Index];
-    }
+    inline HMM_Vec3 &operator[](int Index) { return Columns[Index]; }
+    inline const HMM_Vec3 &operator[](int Index) const { return Columns[Index]; }
 #endif
 } HMM_Mat3;
 
@@ -398,10 +388,8 @@ typedef union HMM_Mat4
     HMM_Vec4 Columns[4];
 
 #ifdef __cplusplus
-    inline HMM_Vec4 &operator[](int Index)
-    {
-        return Columns[Index];
-    }
+    inline HMM_Vec4 &operator[](int Index) { return Columns[Index]; }
+    inline const HMM_Vec4 &operator[](int Index) const { return Columns[Index]; }
 #endif
 } HMM_Mat4;
 


### PR DESCRIPTION
This makes it possible use to do something like
```cpp
const HMM_Vec3 v{1,2,3};
float val = v[1];
```
I've moved the functions to one line, just so that it looks less verbose