### PR TITLE
Add a function for rotating a vector by a quaterion

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -2528,6 +2528,19 @@ static inline HMM_Quat HMM_QFromAxisAngle_LH(HMM_Vec3 Axis, float AngleOfRotatio
 }
 
 
+// implementation from
+// https://blog.molecular-matters.com/2013/05/24/a-faster-quaternion-vector-multiplication/
+COVERAGE(HMM_RotateQV3, 1)
+static inline HMM_Vec3 HMM_RotateQV3(HMM_Quat Q, HMM_Vec3 V)
+{
+    ASSERT_COVERED(HMM_RotateQV3);
+
+    HMM_Vec3 t = HMM_MulV3F(HMM_Cross(Q.XYZ, V), 2);
+    return HMM_AddV3(V, HMM_AddV3(HMM_MulV3F(t, Q.W), HMM_Cross(Q.XYZ, t)));
+}
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -52,7 +52,7 @@
     #define HMM_ACOSF MyACosF
     #define HMM_SQRTF MySqrtF
     #include "HandmadeMath.h"
-  
+
   By default, it is assumed that your math functions take radians. To use
   different units, you must define HMM_ANGLE_USER_TO_INTERNAL and
   HMM_ANGLE_INTERNAL_TO_USER. For example, if you want to use degrees in your
@@ -62,7 +62,7 @@
     #define HMM_ANGLE_INTERNAL_TO_USER(a) ((a)*HMM_TurnToDeg)
 
   =============================================================================
-  
+
   LICENSE
 
   This software is in the public domain. Where that dedication is not
@@ -162,7 +162,7 @@ extern "C"
     && !defined(HANDMADE_MATH_USE_RADIANS)
 # define HANDMADE_MATH_USE_RADIANS
 #endif
-    
+
 #define HMM_PI 3.14159265358979323846
 #define HMM_PI32 3.14159265359f
 #define HMM_DEG180 180.0
@@ -205,7 +205,7 @@ extern "C"
 
 #if !defined(HMM_ANGLE_INTERNAL_TO_USER)
 # if defined(HANDMADE_MATH_USE_RADIANS)
-#  define HMM_ANGLE_INTERNAL_TO_USER(a) (a) 
+#  define HMM_ANGLE_INTERNAL_TO_USER(a) (a)
 # elif defined(HANDMADE_MATH_USE_DEGREES)
 #  define HMM_ANGLE_INTERNAL_TO_USER(a) ((a)*HMM_RadToDeg)
 # elif defined(HANDMADE_MATH_USE_TURNS)
@@ -370,7 +370,7 @@ typedef union HMM_Mat2
     inline const HMM_Vec2 &operator[](int Index) const { return Columns[Index]; }
 #endif
 } HMM_Mat2;
-    
+
 typedef union HMM_Mat3
 {
     float Elements[3][3];
@@ -425,12 +425,12 @@ static inline float HMM_ToRad(float Angle)
 {
 #if defined(HANDMADE_MATH_USE_RADIANS)
     float Result = Angle;
-#elif defined(HANDMADE_MATH_USE_DEGREES) 
+#elif defined(HANDMADE_MATH_USE_DEGREES)
     float Result = Angle * HMM_DegToRad;
 #elif defined(HANDMADE_MATH_USE_TURNS)
     float Result = Angle * HMM_TurnToRad;
 #endif
-    
+
     return Result;
 }
 
@@ -438,12 +438,12 @@ static inline float HMM_ToDeg(float Angle)
 {
 #if defined(HANDMADE_MATH_USE_RADIANS)
     float Result = Angle * HMM_RadToDeg;
-#elif defined(HANDMADE_MATH_USE_DEGREES) 
+#elif defined(HANDMADE_MATH_USE_DEGREES)
     float Result = Angle;
 #elif defined(HANDMADE_MATH_USE_TURNS)
     float Result = Angle * HMM_TurnToDeg;
 #endif
-    
+
     return Result;
 }
 
@@ -451,12 +451,12 @@ static inline float HMM_ToTurn(float Angle)
 {
 #if defined(HANDMADE_MATH_USE_RADIANS)
     float Result = Angle * HMM_RadToTurn;
-#elif defined(HANDMADE_MATH_USE_DEGREES) 
+#elif defined(HANDMADE_MATH_USE_DEGREES)
     float Result = Angle * HMM_DegToTurn;
 #elif defined(HANDMADE_MATH_USE_TURNS)
     float Result = Angle;
 #endif
-    
+
     return Result;
 }
 
@@ -1036,21 +1036,21 @@ static inline HMM_Vec4 HMM_NormV4(HMM_Vec4 A)
  */
 
 COVERAGE(HMM_LerpV2, 1)
-static inline HMM_Vec2 HMM_LerpV2(HMM_Vec2 A, float Time, HMM_Vec2 B) 
+static inline HMM_Vec2 HMM_LerpV2(HMM_Vec2 A, float Time, HMM_Vec2 B)
 {
     ASSERT_COVERED(HMM_LerpV2);
     return HMM_AddV2(HMM_MulV2F(A, 1.0f - Time), HMM_MulV2F(B, Time));
 }
 
 COVERAGE(HMM_LerpV3, 1)
-static inline HMM_Vec3 HMM_LerpV3(HMM_Vec3 A, float Time, HMM_Vec3 B) 
+static inline HMM_Vec3 HMM_LerpV3(HMM_Vec3 A, float Time, HMM_Vec3 B)
 {
     ASSERT_COVERED(HMM_LerpV3);
     return HMM_AddV3(HMM_MulV3F(A, 1.0f - Time), HMM_MulV3F(B, Time));
 }
 
 COVERAGE(HMM_LerpV4, 1)
-static inline HMM_Vec4 HMM_LerpV4(HMM_Vec4 A, float Time, HMM_Vec4 B) 
+static inline HMM_Vec4 HMM_LerpV4(HMM_Vec4 A, float Time, HMM_Vec4 B)
 {
     ASSERT_COVERED(HMM_LerpV4);
     return HMM_AddV4(HMM_MulV4F(A, 1.0f - Time), HMM_MulV4F(B, Time));
@@ -1112,7 +1112,7 @@ COVERAGE(HMM_M2D, 1)
 static inline HMM_Mat2 HMM_M2D(float Diagonal)
 {
     ASSERT_COVERED(HMM_M2D);
-    
+
     HMM_Mat2 Result = {0};
     Result.Elements[0][0] = Diagonal;
     Result.Elements[1][1] = Diagonal;
@@ -1124,12 +1124,12 @@ COVERAGE(HMM_TransposeM2, 1)
 static inline HMM_Mat2 HMM_TransposeM2(HMM_Mat2 Matrix)
 {
     ASSERT_COVERED(HMM_TransposeM2);
-    
+
     HMM_Mat2 Result = Matrix;
 
     Result.Elements[0][1] = Matrix.Elements[1][0];
     Result.Elements[1][0] = Matrix.Elements[0][1];
-    
+
     return Result;
 }
 
@@ -1137,29 +1137,29 @@ COVERAGE(HMM_AddM2, 1)
 static inline HMM_Mat2 HMM_AddM2(HMM_Mat2 Left, HMM_Mat2 Right)
 {
     ASSERT_COVERED(HMM_AddM2);
-    
+
     HMM_Mat2 Result;
 
     Result.Elements[0][0] = Left.Elements[0][0] + Right.Elements[0][0];
     Result.Elements[0][1] = Left.Elements[0][1] + Right.Elements[0][1];
     Result.Elements[1][0] = Left.Elements[1][0] + Right.Elements[1][0];
     Result.Elements[1][1] = Left.Elements[1][1] + Right.Elements[1][1];
-   
-    return Result;    
+
+    return Result;
 }
 
 COVERAGE(HMM_SubM2, 1)
 static inline HMM_Mat2 HMM_SubM2(HMM_Mat2 Left, HMM_Mat2 Right)
 {
     ASSERT_COVERED(HMM_SubM2);
-    
+
     HMM_Mat2 Result;
 
     Result.Elements[0][0] = Left.Elements[0][0] - Right.Elements[0][0];
     Result.Elements[0][1] = Left.Elements[0][1] - Right.Elements[0][1];
     Result.Elements[1][0] = Left.Elements[1][0] - Right.Elements[1][0];
     Result.Elements[1][1] = Left.Elements[1][1] - Right.Elements[1][1];
-    
+
     return Result;
 }
 
@@ -1167,7 +1167,7 @@ COVERAGE(HMM_MulM2V2, 1)
 static inline HMM_Vec2 HMM_MulM2V2(HMM_Mat2 Matrix, HMM_Vec2 Vector)
 {
     ASSERT_COVERED(HMM_MulM2V2);
-    
+
     HMM_Vec2 Result;
 
     Result.X = Vector.Elements[0] * Matrix.Columns[0].X;
@@ -1176,33 +1176,33 @@ static inline HMM_Vec2 HMM_MulM2V2(HMM_Mat2 Matrix, HMM_Vec2 Vector)
     Result.X += Vector.Elements[1] * Matrix.Columns[1].X;
     Result.Y += Vector.Elements[1] * Matrix.Columns[1].Y;
 
-    return Result;    
+    return Result;
 }
 
 COVERAGE(HMM_MulM2, 1)
 static inline HMM_Mat2 HMM_MulM2(HMM_Mat2 Left, HMM_Mat2 Right)
 {
     ASSERT_COVERED(HMM_MulM2);
-    
+
     HMM_Mat2 Result;
     Result.Columns[0] = HMM_MulM2V2(Left, Right.Columns[0]);
     Result.Columns[1] = HMM_MulM2V2(Left, Right.Columns[1]);
 
-    return Result;    
+    return Result;
 }
 
 COVERAGE(HMM_MulM2F, 1)
 static inline HMM_Mat2 HMM_MulM2F(HMM_Mat2 Matrix, float Scalar)
 {
     ASSERT_COVERED(HMM_MulM2F);
-    
+
     HMM_Mat2 Result;
 
     Result.Elements[0][0] = Matrix.Elements[0][0] * Scalar;
     Result.Elements[0][1] = Matrix.Elements[0][1] * Scalar;
     Result.Elements[1][0] = Matrix.Elements[1][0] * Scalar;
     Result.Elements[1][1] = Matrix.Elements[1][1] * Scalar;
-    
+
     return Result;
 }
 
@@ -1210,7 +1210,7 @@ COVERAGE(HMM_DivM2F, 1)
 static inline HMM_Mat2 HMM_DivM2F(HMM_Mat2 Matrix, float Scalar)
 {
     ASSERT_COVERED(HMM_DivM2F);
-    
+
     HMM_Mat2 Result;
 
     Result.Elements[0][0] = Matrix.Elements[0][0] / Scalar;
@@ -1222,7 +1222,7 @@ static inline HMM_Mat2 HMM_DivM2F(HMM_Mat2 Matrix, float Scalar)
 }
 
 COVERAGE(HMM_DeterminantM2, 1)
-static inline float HMM_DeterminantM2(HMM_Mat2 Matrix) 
+static inline float HMM_DeterminantM2(HMM_Mat2 Matrix)
 {
     ASSERT_COVERED(HMM_DeterminantM2);
     return Matrix.Elements[0][0]*Matrix.Elements[1][1] - Matrix.Elements[0][1]*Matrix.Elements[1][0];
@@ -1230,7 +1230,7 @@ static inline float HMM_DeterminantM2(HMM_Mat2 Matrix)
 
 
 COVERAGE(HMM_InvGeneralM2, 1)
-static inline HMM_Mat2 HMM_InvGeneralM2(HMM_Mat2 Matrix) 
+static inline HMM_Mat2 HMM_InvGeneralM2(HMM_Mat2 Matrix)
 {
     ASSERT_COVERED(HMM_InvGeneralM2);
 
@@ -1260,7 +1260,7 @@ COVERAGE(HMM_M3D, 1)
 static inline HMM_Mat3 HMM_M3D(float Diagonal)
 {
     ASSERT_COVERED(HMM_M3D);
-    
+
     HMM_Mat3 Result = {0};
     Result.Elements[0][0] = Diagonal;
     Result.Elements[1][1] = Diagonal;
@@ -1282,7 +1282,7 @@ static inline HMM_Mat3 HMM_TransposeM3(HMM_Mat3 Matrix)
     Result.Elements[1][2] = Matrix.Elements[2][1];
     Result.Elements[2][1] = Matrix.Elements[1][2];
     Result.Elements[2][0] = Matrix.Elements[0][2];
-    
+
     return Result;
 }
 
@@ -1290,9 +1290,9 @@ COVERAGE(HMM_AddM3, 1)
 static inline HMM_Mat3 HMM_AddM3(HMM_Mat3 Left, HMM_Mat3 Right)
 {
     ASSERT_COVERED(HMM_AddM3);
-    
+
     HMM_Mat3 Result;
-    
+
     Result.Elements[0][0] = Left.Elements[0][0] + Right.Elements[0][0];
     Result.Elements[0][1] = Left.Elements[0][1] + Right.Elements[0][1];
     Result.Elements[0][2] = Left.Elements[0][2] + Right.Elements[0][2];
@@ -1303,7 +1303,7 @@ static inline HMM_Mat3 HMM_AddM3(HMM_Mat3 Left, HMM_Mat3 Right)
     Result.Elements[2][1] = Left.Elements[2][1] + Right.Elements[2][1];
     Result.Elements[2][2] = Left.Elements[2][2] + Right.Elements[2][2];
 
-    return Result;    
+    return Result;
 }
 
 COVERAGE(HMM_SubM3, 1)
@@ -1330,7 +1330,7 @@ COVERAGE(HMM_MulM3V3, 1)
 static inline HMM_Vec3 HMM_MulM3V3(HMM_Mat3 Matrix, HMM_Vec3 Vector)
 {
     ASSERT_COVERED(HMM_MulM3V3);
-    
+
     HMM_Vec3 Result;
 
     Result.X = Vector.Elements[0] * Matrix.Columns[0].X;
@@ -1344,8 +1344,8 @@ static inline HMM_Vec3 HMM_MulM3V3(HMM_Mat3 Matrix, HMM_Vec3 Vector)
     Result.X += Vector.Elements[2] * Matrix.Columns[2].X;
     Result.Y += Vector.Elements[2] * Matrix.Columns[2].Y;
     Result.Z += Vector.Elements[2] * Matrix.Columns[2].Z;
-    
-    return Result;    
+
+    return Result;
 }
 
 COVERAGE(HMM_MulM3, 1)
@@ -1358,7 +1358,7 @@ static inline HMM_Mat3 HMM_MulM3(HMM_Mat3 Left, HMM_Mat3 Right)
     Result.Columns[1] = HMM_MulM3V3(Left, Right.Columns[1]);
     Result.Columns[2] = HMM_MulM3V3(Left, Right.Columns[2]);
 
-    return Result;    
+    return Result;
 }
 
 COVERAGE(HMM_MulM3F, 1)
@@ -1378,7 +1378,7 @@ static inline HMM_Mat3 HMM_MulM3F(HMM_Mat3 Matrix, float Scalar)
     Result.Elements[2][1] = Matrix.Elements[2][1] * Scalar;
     Result.Elements[2][2] = Matrix.Elements[2][2] * Scalar;
 
-    return Result;            
+    return Result;
 }
 
 COVERAGE(HMM_DivM3, 1)
@@ -1387,7 +1387,7 @@ static inline HMM_Mat3 HMM_DivM3F(HMM_Mat3 Matrix, float Scalar)
     ASSERT_COVERED(HMM_DivM3);
 
     HMM_Mat3 Result;
-    
+
     Result.Elements[0][0] = Matrix.Elements[0][0] / Scalar;
     Result.Elements[0][1] = Matrix.Elements[0][1] / Scalar;
     Result.Elements[0][2] = Matrix.Elements[0][2] / Scalar;
@@ -1398,11 +1398,11 @@ static inline HMM_Mat3 HMM_DivM3F(HMM_Mat3 Matrix, float Scalar)
     Result.Elements[2][1] = Matrix.Elements[2][1] / Scalar;
     Result.Elements[2][2] = Matrix.Elements[2][2] / Scalar;
 
-    return Result;                    
+    return Result;
 }
 
 COVERAGE(HMM_DeterminantM3, 1)
-static inline float HMM_DeterminantM3(HMM_Mat3 Matrix) 
+static inline float HMM_DeterminantM3(HMM_Mat3 Matrix)
 {
     ASSERT_COVERED(HMM_DeterminantM3);
 
@@ -1415,7 +1415,7 @@ static inline float HMM_DeterminantM3(HMM_Mat3 Matrix)
 }
 
 COVERAGE(HMM_InvGeneralM3, 1)
-static inline HMM_Mat3 HMM_InvGeneralM3(HMM_Mat3 Matrix) 
+static inline HMM_Mat3 HMM_InvGeneralM3(HMM_Mat3 Matrix)
 {
     ASSERT_COVERED(HMM_InvGeneralM3);
 
@@ -1550,7 +1550,7 @@ static inline HMM_Mat4 HMM_SubM4(HMM_Mat4 Left, HMM_Mat4 Right)
     Result.Elements[3][2] = Left.Elements[3][2] - Right.Elements[3][2];
     Result.Elements[3][3] = Left.Elements[3][3] - Right.Elements[3][3];
 #endif
- 
+
     return Result;
 }
 
@@ -1646,7 +1646,7 @@ static inline HMM_Mat4 HMM_DivM4F(HMM_Mat4 Matrix, float Scalar)
 }
 
 COVERAGE(HMM_DeterminantM4, 1)
-static inline float HMM_DeterminantM4(HMM_Mat4 Matrix) 
+static inline float HMM_DeterminantM4(HMM_Mat4 Matrix)
 {
     ASSERT_COVERED(HMM_DeterminantM4);
 
@@ -1654,14 +1654,14 @@ static inline float HMM_DeterminantM4(HMM_Mat4 Matrix)
     HMM_Vec3 C23 = HMM_Cross(Matrix.Columns[2].XYZ, Matrix.Columns[3].XYZ);
     HMM_Vec3 B10 = HMM_SubV3(HMM_MulV3F(Matrix.Columns[0].XYZ, Matrix.Columns[1].W), HMM_MulV3F(Matrix.Columns[1].XYZ, Matrix.Columns[0].W));
     HMM_Vec3 B32 = HMM_SubV3(HMM_MulV3F(Matrix.Columns[2].XYZ, Matrix.Columns[3].W), HMM_MulV3F(Matrix.Columns[3].XYZ, Matrix.Columns[2].W));
-    
+
     return HMM_DotV3(C01, B32) + HMM_DotV3(C23, B10);
 }
 
 COVERAGE(HMM_InvGeneralM4, 1)
 // Returns a general-purpose inverse of an HMM_Mat4. Note that special-purpose inverses of many transformations
 // are available and will be more efficient.
-static inline HMM_Mat4 HMM_InvGeneralM4(HMM_Mat4 Matrix) 
+static inline HMM_Mat4 HMM_InvGeneralM4(HMM_Mat4 Matrix)
 {
     ASSERT_COVERED(HMM_InvGeneralM4);
 
@@ -1669,7 +1669,7 @@ static inline HMM_Mat4 HMM_InvGeneralM4(HMM_Mat4 Matrix)
     HMM_Vec3 C23 = HMM_Cross(Matrix.Columns[2].XYZ, Matrix.Columns[3].XYZ);
     HMM_Vec3 B10 = HMM_SubV3(HMM_MulV3F(Matrix.Columns[0].XYZ, Matrix.Columns[1].W), HMM_MulV3F(Matrix.Columns[1].XYZ, Matrix.Columns[0].W));
     HMM_Vec3 B32 = HMM_SubV3(HMM_MulV3F(Matrix.Columns[2].XYZ, Matrix.Columns[3].W), HMM_MulV3F(Matrix.Columns[3].XYZ, Matrix.Columns[2].W));
-    
+
     float InvDeterminant = 1.0f / (HMM_DotV3(C01, B32) + HMM_DotV3(C23, B10));
     C01 = HMM_MulV3F(C01, InvDeterminant);
     C23 = HMM_MulV3F(C23, InvDeterminant);
@@ -1681,7 +1681,7 @@ static inline HMM_Mat4 HMM_InvGeneralM4(HMM_Mat4 Matrix)
     Result.Columns[1] = HMM_V4V(HMM_SubV3(HMM_Cross(B32, Matrix.Columns[0].XYZ), HMM_MulV3F(C23, Matrix.Columns[0].W)), +HMM_DotV3(Matrix.Columns[0].XYZ, C23));
     Result.Columns[2] = HMM_V4V(HMM_AddV3(HMM_Cross(Matrix.Columns[3].XYZ, B10), HMM_MulV3F(C01, Matrix.Columns[3].W)), -HMM_DotV3(Matrix.Columns[3].XYZ, C01));
     Result.Columns[3] = HMM_V4V(HMM_SubV3(HMM_Cross(B10, Matrix.Columns[2].XYZ), HMM_MulV3F(C01, Matrix.Columns[2].W)), +HMM_DotV3(Matrix.Columns[2].XYZ, C01));
-        
+
     return HMM_TransposeM4(Result);
 }
 
@@ -1743,7 +1743,7 @@ static inline HMM_Mat4 HMM_Orthographic_LH_NO(float Left, float Right, float Bot
 
     HMM_Mat4 Result = HMM_Orthographic_RH_NO(Left, Right, Bottom, Top, Near, Far);
     Result.Elements[2][2] = -Result.Elements[2][2];
-    
+
     return Result;
 }
 
@@ -1757,7 +1757,7 @@ static inline HMM_Mat4 HMM_Orthographic_LH_ZO(float Left, float Right, float Bot
 
     HMM_Mat4 Result = HMM_Orthographic_RH_ZO(Left, Right, Bottom, Top, Near, Far);
     Result.Elements[2][2] = -Result.Elements[2][2];
-    
+
     return Result;
 }
 
@@ -1773,7 +1773,7 @@ static inline HMM_Mat4 HMM_InvOrthographic(HMM_Mat4 OrthoMatrix)
     Result.Elements[1][1] = 1.0f / OrthoMatrix.Elements[1][1];
     Result.Elements[2][2] = 1.0f / OrthoMatrix.Elements[2][2];
     Result.Elements[3][3] = 1.0f;
-    
+
     Result.Elements[3][0] = -OrthoMatrix.Elements[3][0] * Result.Elements[0][0];
     Result.Elements[3][1] = -OrthoMatrix.Elements[3][1] * Result.Elements[1][1];
     Result.Elements[3][2] = -OrthoMatrix.Elements[3][2] * Result.Elements[2][2];
@@ -1797,7 +1797,7 @@ static inline HMM_Mat4 HMM_Perspective_RH_NO(float FOV, float AspectRatio, float
 
     Result.Elements[2][2] = (Near + Far) / (Near - Far);
     Result.Elements[3][2] = (2.0f * Near * Far) / (Near - Far);
-    
+
     return Result;
 }
 
@@ -1823,25 +1823,25 @@ static inline HMM_Mat4 HMM_Perspective_RH_ZO(float FOV, float AspectRatio, float
 
 COVERAGE(HMM_Perspective_LH_NO, 1)
 static inline HMM_Mat4 HMM_Perspective_LH_NO(float FOV, float AspectRatio, float Near, float Far)
-{ 
+{
     ASSERT_COVERED(HMM_Perspective_LH_NO);
 
     HMM_Mat4 Result = HMM_Perspective_RH_NO(FOV, AspectRatio, Near, Far);
     Result.Elements[2][2] = -Result.Elements[2][2];
     Result.Elements[2][3] = -Result.Elements[2][3];
-    
+
     return Result;
 }
 
 COVERAGE(HMM_Perspective_LH_ZO, 1)
 static inline HMM_Mat4 HMM_Perspective_LH_ZO(float FOV, float AspectRatio, float Near, float Far)
-{ 
+{
     ASSERT_COVERED(HMM_Perspective_LH_ZO);
 
     HMM_Mat4 Result = HMM_Perspective_RH_ZO(FOV, AspectRatio, Near, Far);
     Result.Elements[2][2] = -Result.Elements[2][2];
     Result.Elements[2][3] = -Result.Elements[2][3];
-    
+
     return Result;
 }
 
@@ -1962,7 +1962,7 @@ static inline HMM_Mat4 HMM_Scale(HMM_Vec3 Scale)
 }
 
 COVERAGE(HMM_InvScale, 1)
-static inline HMM_Mat4 HMM_InvScale(HMM_Mat4 ScaleMatrix) 
+static inline HMM_Mat4 HMM_InvScale(HMM_Mat4 ScaleMatrix)
 {
     ASSERT_COVERED(HMM_InvScale);
 
@@ -2166,7 +2166,7 @@ static inline HMM_Quat HMM_MulQ(HMM_Quat Left, HMM_Quat Right)
     Result.Y += Right.Elements[3] * +Left.Elements[1];
     Result.Z += Right.Elements[0] * -Left.Elements[1];
     Result.W += Right.Elements[1] * -Left.Elements[1];
-    
+
     Result.X += Right.Elements[1] * -Left.Elements[2];
     Result.Y += Right.Elements[0] * +Left.Elements[2];
     Result.Z += Right.Elements[3] * +Left.Elements[2];
@@ -2246,7 +2246,7 @@ COVERAGE(HMM_InvQ, 1)
 static inline HMM_Quat HMM_InvQ(HMM_Quat Left)
 {
     ASSERT_COVERED(HMM_InvQ);
-    
+
     HMM_Quat Result;
     Result.X = -Left.X;
     Result.Y = -Left.Y;
@@ -2312,7 +2312,7 @@ static inline HMM_Quat HMM_SLerp(HMM_Quat Left, float Time, HMM_Quat Right)
         Cos_Theta = -Cos_Theta;
         Right = HMM_Q(-Right.X, -Right.Y, -Right.Z, -Right.W);
     }
-    
+
     /* NOTE(lcf): Use Normalized Linear interpolation when vectors are roughly not L.I. */
     if (Cos_Theta > 0.9995f) {
         Result = HMM_NLerp(Left, Time, Right);
@@ -2324,7 +2324,7 @@ static inline HMM_Quat HMM_SLerp(HMM_Quat Left, float Time, HMM_Quat Right)
         Result = _HMM_MixQ(Left, MixLeft, Right, MixRight);
         Result = HMM_NormQ(Result);
     }
-    
+
     return Result;
 }
 
@@ -2637,23 +2637,23 @@ static inline float HMM_Dot(HMM_Vec4 Left, HMM_Vec4 VecTwo)
     ASSERT_COVERED(HMM_DotV4CPP);
     return HMM_DotV4(Left, VecTwo);
 }
- 
+
 COVERAGE(HMM_LerpV2CPP, 1)
-static inline HMM_Vec2 HMM_Lerp(HMM_Vec2 Left, float Time, HMM_Vec2 Right) 
+static inline HMM_Vec2 HMM_Lerp(HMM_Vec2 Left, float Time, HMM_Vec2 Right)
 {
     ASSERT_COVERED(HMM_LerpV2CPP);
     return HMM_LerpV2(Left, Time, Right);
 }
 
 COVERAGE(HMM_LerpV3CPP, 1)
-static inline HMM_Vec3 HMM_Lerp(HMM_Vec3 Left, float Time, HMM_Vec3 Right) 
+static inline HMM_Vec3 HMM_Lerp(HMM_Vec3 Left, float Time, HMM_Vec3 Right)
 {
     ASSERT_COVERED(HMM_LerpV3CPP);
     return HMM_LerpV3(Left, Time, Right);
 }
 
 COVERAGE(HMM_LerpV4CPP, 1)
-static inline HMM_Vec4 HMM_Lerp(HMM_Vec4 Left, float Time, HMM_Vec4 Right) 
+static inline HMM_Vec4 HMM_Lerp(HMM_Vec4 Left, float Time, HMM_Vec4 Right)
 {
     ASSERT_COVERED(HMM_LerpV4CPP);
     return HMM_LerpV4(Left, Time, Right);

--- a/test/categories/QuaternionOps.h
+++ b/test/categories/QuaternionOps.h
@@ -274,3 +274,25 @@ TEST(QuaternionOps, FromAxisAngle)
         EXPECT_NEAR(result.W, 0.707107f, 0.001f);
     }
 }
+
+TEST(QuaternionOps, RotateVector)
+{
+    {
+        HMM_Vec3 axis = HMM_V3(0.0f, 1.0f, 0.0f);
+        float angle = -HMM_PI32 / 2.0f;
+        HMM_Quat q = HMM_QFromAxisAngle_RH(axis, angle);
+        HMM_Vec3 result = HMM_RotateQV3(q, HMM_V3(1.0f, 0.0f, 0.0f));
+        EXPECT_NEAR(result.X, 0.0f, 0.001f);
+        EXPECT_NEAR(result.Y, 0.0f, 0.001f);
+        EXPECT_NEAR(result.Z, 1.0f, 0.001f);
+    }
+    {
+        HMM_Vec3 axis = HMM_V3(1.0f, 0.0f, 0.0f);
+        float angle = HMM_PI32 / 4.0f;
+        HMM_Quat q = HMM_QFromAxisAngle_RH(axis, angle);
+        HMM_Vec3 result = HMM_RotateQV3(q, HMM_V3(0.0f, 0.0f, 1.0f));
+        EXPECT_NEAR(result.X, 0.0f, 0.001f);
+        EXPECT_NEAR(result.Y, -0.707170f, 0.001f);
+        EXPECT_NEAR(result.Z, 0.707170f, 0.001f);
+    }
+}


### PR DESCRIPTION
Resolves #141. The implementation should be simpler than #142
I'm not sure if `HMM_RotateQV3()` follows the proper naming convention, suggestions welcome