### PR TITLE
Ignore missing braces warning for all GCC versions

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -147,9 +147,7 @@
 #if defined(__GNUC__) || defined(__clang__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wfloat-equal"
-# if (defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 8)) || defined(__clang__)
-#  pragma GCC diagnostic ignored "-Wmissing-braces"
-# endif
+# pragma GCC diagnostic ignored "-Wmissing-braces"
 # ifdef __clang__
 #  pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"


### PR DESCRIPTION
If I compile with GCC version 13.2.1 and warnings enabled I encounter a warning about missing braces. Currently missing braces seems to only be ignored for GCC versions with major 4 and minor < 8. Not familiar with why this choice was made, but I fail to see why we can't just ignore this for all GCC versions.